### PR TITLE
Explicitly install package Microsoft.Extensions.DependencyModel. 

### DIFF
--- a/src/FileReceiver.Infrastructure.Configuration/FileReceiver.Infrastructure.Configuration.csproj
+++ b/src/FileReceiver.Infrastructure.Configuration/FileReceiver.Infrastructure.Configuration.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="5.0.0" />
       <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
       <PackageReference Include="Serilog" Version="2.10.0" />
       <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0" />


### PR DESCRIPTION
At Azure bot API can't start because this package isn't found